### PR TITLE
adding litterfall to tpars

### DIFF
--- a/functions/MIMICS_sim_litterbag.R
+++ b/functions/MIMICS_sim_litterbag.R
@@ -19,7 +19,9 @@ MIMICS_LITBAG <- function(forcing_df, litBAG, dailyInput=NA, loop_dailyInput=TRU
     print(paste0("Starting ", forcing_df$SITE, " - ", litBAG[1]))
     print("-------------------------------------------------------")
   }
-  
+  # drop litterfall if proivded
+  forcing_df_ss = forcing_df %>%
+    select(ANPP, TSOI, CLAY, LIG_N, GWC, W_SCALAR) 
   # Get MIMICS steady_state output
   MIMss <- MIMICS_SS(forcing_df)
 

--- a/functions/calc_Tpars.R
+++ b/functions/calc_Tpars.R
@@ -12,7 +12,7 @@
 # -- historic is a logical for using historic MAT to modify Vslope & Vint
 
 calc_Tpars_Conly <- function(ANPP, fCLAY, TSOI, MAT=NA, CN, LIG, LIG_N=NA,
-                             theta_liq=NA, theta_frzn=NA, W_SCALAR=NA) {
+                             theta_liq=NA, theta_frzn=NA, W_SCALAR=NA, litfall=NA) {
   
   # Set lig:N value if not given
   if (is.na(LIG_N)) {
@@ -56,9 +56,13 @@ calc_Tpars_Conly <- function(ANPP, fCLAY, TSOI, MAT=NA, CN, LIG, LIG_N=NA,
   }
 
   
-  # Calc litter input rate
-  EST_LIT <- (ANPP / (365*24)) * 1e3 / 1e4
-
+  # Calc litter input rate from annual or daily flux then convert units
+  if (is.na(litfall)) {
+    EST_LIT <- (ANPP / (365*24)) * 1e3 / 1e4
+  } else {
+    EST_LIT <- (litfall / 24) * 1e3 / 1e4
+  }
+  
   # ------------ calculate time varying parameters ---------------
   Vmax     <- exp(TSOI * Vslope + Vint) * aV * fW   #<-- Moisture scalar applied
   Km       <- exp(TSOI * Kslope + Kint) * aK


### PR DESCRIPTION
Key changes are to calc_tpars, separating out ANPP from litterfall fluxes.  ANPP is used for tau_mod and should not be time varying, whereas litterfall inputs can vary with time as inputs (if provided).

A bunch of the changes to MS_BioLitBag_runs were just for my own sanity and may not be needed, but we do need to pass litterfall fluxes with daily dataframe.

